### PR TITLE
Support Symfony 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         "php": ">=7.3",
         "guzzlehttp/guzzle": "^7.3",
         "psr/log": "^1.1",
-        "symfony/process": "^5.3"
+        "symfony/process": "^5.3 || ^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5.8",


### PR DESCRIPTION
Hello!

This change is required for the package to be installed in a Symfony 6.0 installation.

I manually tried the cuzzle package with the new Symfony 6.0 demo, and it works just fine

Symfony changelog shows no changes in version 6.0 for the `process` component https://github.com/symfony/process/blob/5.4/CHANGELOG.md

When trying to use this package in a symfony installation, the `symfony/process` dependency does not allow it to be installed because of this json block inside composer.json, forcing all `symfony/*` packages to be at least version 6
```
    "extra": {
        "symfony": {
            "allow-contrib": true,
            "require": "6.0.*"
        }
    }
```